### PR TITLE
Add default input/textarea background color

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -46,6 +46,7 @@ textarea.input {
 	font-size: @input-font-size;
 	line-height: @input-line-height;
 	transition: box-shadow .15s, border-color .15s, background-color .15s, color .15s;
+	background-color: #fff;
 	box-shadow: 0 1px 1px rgba(0,0,0,.05) inset;
 	appearance: none;
 	outline: none;


### PR DESCRIPTION
This commit fix default background color on web browser with dark UI (e.g. Dark theme on KDE) to white.

![before fix - screenshot_20161217_204015](https://cloud.githubusercontent.com/assets/830515/21286498/098e8074-c499-11e6-8537-ec0772f56e8e.png)
