### PR TITLE
Support webcomponents (Use :host-context for dark style overrides)

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -91,7 +91,7 @@
 
 	& when (@include-dark = true) {
 		// dark style
-		.dark &, &.ondark {
+		.dark & {
 			& {
 				.colorset(@alert-color);
 				background-color: darken(@color-d2,10%);

--- a/less/alerts.less
+++ b/less/alerts.less
@@ -43,99 +43,42 @@
 		}
 	}
 
-	// colors
-	& {
-		.colorset(@alert-color);
+	// mixin
+	.generate-alert-colors(@color) {
+		.colorset(@color);
 		background-color: lighten(@color-l2,7%);
+
+		.dark-override({
+			background-color: darken(@color-d2,10%);
+		});
 
 		.alert-icon {
 			color: @color-d2;
+
+			.dark-override({
+				color: @color-l1;
+			});
 		}
+	}
+
+	// colors
+	& {
+		.generate-alert-colors(@alert-color);
 	}
 
 	&.accent {
-		.colorset(@alert-accent-color);
-		background-color: lighten(@color-l2,7%);
-
-		.alert-icon {
-			color: @color-d2;
-		}
+		.generate-alert-colors(@alert-accent-color);
 	}
 
 	&.okay {
-		.colorset(@alert-okay-color);
-		background-color: lighten(@color-l2,7%);
-
-		.alert-icon {
-			color: @color-d2;
-		}
+		.generate-alert-colors(@alert-okay-color);
 	}
 
 	&.warning {
-		.colorset(@alert-warning-color);
-		background-color: lighten(@color-l2,7%);
-
-		.alert-icon {
-			color: @color-d2;
-		}
+		.generate-alert-colors(@alert-warning-color);
 	}
 
 	&.danger {
-		.colorset(@alert-danger-color);
-		background-color: lighten(@color-l2,7%);
-
-		.alert-icon {
-			color: @color-d2;
-		}
-	}
-
-	& when (@include-dark = true) {
-		// dark style
-		.dark & {
-			& {
-				.colorset(@alert-color);
-				background-color: darken(@color-d2,10%);
-
-				.alert-icon {
-					color: @color-l1;
-				}
-			}
-
-			&.accent {
-				.colorset(@alert-accent-color);
-				background-color: darken(@color-d2,10%);
-
-				.alert-icon {
-					color: @color-l1;
-				}
-			}
-
-			&.okay {
-				.colorset(@alert-okay-color);
-				background-color: darken(@color-d2,10%);
-
-				.alert-icon {
-					color: @color-l1;
-				}
-			}
-
-			&.warning {
-				.colorset(@alert-warning-color);
-				background-color: darken(@color-d2,10%);
-
-				.alert-icon {
-					color: @color-l1;
-				}
-			}
-
-			&.danger {
-				.colorset(@alert-danger-color);
-				background-color: darken(@color-d2,10%);
-
-				.alert-icon {
-					color: @color-l1;
-				}
-			}
-		}
+		.generate-alert-colors(@alert-danger-color);
 	}
 }

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -196,7 +196,7 @@
 
 			& when (@include-dark = true) {
 				// on dark background
-				&.ondark, .dark & {
+				.dark & {
 
 					// for toggle button
 					&.active {

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -194,12 +194,45 @@
 				border-color: transparent !important;
 			}
 
-			& when (@include-dark = true) {
-				// on dark background
-				.dark & {
+			// for toggle button
+			.dark-override({
+				&.active {
+					color: @text-color;
+					background-color: @color-d1;
+					border-color: @color-l2;
 
-					// for toggle button
-					&.active {
+					&:hover {
+						border-color: @color-l2;
+						background-color: @color;
+					}
+					&:focus {
+						color: @text-color;
+						border-color: @color-d1;
+						box-shadow: 0 0px 2px rgba(0,0,0,.3);
+					}
+				}
+
+				&:hover {
+					background-color: @color-d1;
+					border-color: @color-l1;
+				}
+
+				&:focus {
+					border-color: @color-l2;
+				}
+
+				&:active {
+					background-color: @color-d2;
+					border-color: @color;
+				}
+
+			});
+
+			// for segmented button active state on dark
+			& when (@include-dark = true) {
+				& when (@use-webcomponents = false) {
+					.dark :checked + label &,
+					.dark :checked + label &.hollow {
 						color: @text-color;
 						background-color: @color-d1;
 						border-color: @color-l2;
@@ -208,38 +241,19 @@
 							border-color: @color-l2;
 							background-color: @color;
 						}
-						&:focus {
-							color: @text-color;
-							border-color: @color-d1;
-							box-shadow: 0 0px 2px rgba(0,0,0,.3);
-						}
-					}
-
-					&:hover {
-						background-color: @color-d1;
-						border-color: @color-l1;
-					}
-
-					&:focus {
-						border-color: @color-l2;
-					}
-
-					&:active {
-						background-color: @color-d2;
-						border-color: @color;
 					}
 				}
-
-				// for segmented button active state on dark
-				.dark :checked + label &,
-				.dark :checked + label &.hollow {
-					color: @text-color;
-					background-color: @color-d1;
-					border-color: @color-l2;
-
-					&:hover {
+				& when (@use-webcomponents = true) {
+					:host-context(.dark) :checked + label &,
+					:host-context(.dark) :checked + label &.hollow {
+						color: @text-color;
+						background-color: @color-d1;
 						border-color: @color-l2;
-						background-color: @color;
+
+						&:hover {
+							border-color: @color-l2;
+							background-color: @color;
+						}
 					}
 				}
 			}
@@ -274,18 +288,18 @@
 					border-color: @color-d2;
 				}
 
-				& when (@include-dark = true) {
-					.dark &:focus {
+				.dark-override({
+					&:focus {
 						color: @color-l1;
 						border-color: @color-l1;
 					}
-					.dark &:focus:hover {
+					&:focus:hover {
 						color: @text-color;
 					}
-					.dark &:active {
+					&:active {
 						border-color: @color-l1;
 					}
-				}
+				});
 
 				& when (@include-btn-dropdown = true) {
 					&:hover, &:active,
@@ -656,11 +670,11 @@ fieldset[disabled] .btn,
 				}
 			}
 
-			& when (@include-dark = true) {
-				.dark & .btn + .btn.dropdown:not(.hollow):before {
+			.dark-override({
+				.btn + .btn.dropdown:not(.hollow):before {
 					background: rgba(255,255,255,0.3);
 				}
-			}
+			});
 
 			// active override
 			&.active .btn + .btn.dropdown {

--- a/less/forms.less
+++ b/less/forms.less
@@ -71,7 +71,7 @@ textarea.input {
 	}
 
 	& when (@include-dark = true) {
-		.dark &, &.ondark {
+		.dark & {
 			border-color: @gray;
 			background-color: fadeout(@black,60%);
 
@@ -133,7 +133,7 @@ textarea.input {
 		opacity: 0.7;
 
 		& when (@include-dark = true) {
-			.dark &, &.ondark {
+			.dark & {
 				border-color: @gray-d1;
 			}
 		}
@@ -144,7 +144,7 @@ textarea.input {
 		background-color: fadeout(@gray,90%);
 
 		& when (@include-dark = true) {
-			.dark &, &.ondark {
+			.dark & {
 			}
 		}
 	}
@@ -471,7 +471,7 @@ textarea.input {
 		border-right-width: 0;
 
 		& when (@include-dark = true) {
-			.dark &, &.ondark {
+			.dark & {
 				border-color: @gray;
 			}
 		}
@@ -1085,7 +1085,7 @@ select.select {
 
 	& when (@include-dark = true) {
 		// dark mode
-		.dark &, &.ondark {
+		.dark & {
 			background-color: #000;
 			color: #fff;
 
@@ -1517,7 +1517,7 @@ select.select {
 
 		& when (@include-dark = true) {
 			// dark
-			.dark &, &.ondark {
+			.dark & {
 				color: #fff;
 
 				.selecter-selected {

--- a/less/forms.less
+++ b/less/forms.less
@@ -70,20 +70,19 @@ textarea.input {
 		.drop-shadow-light;
 	}
 
-	& when (@include-dark = true) {
-		.dark & {
-			border-color: @gray;
-			background-color: fadeout(@black,60%);
+	.dark-override({
+		color: #fff;
+		border-color: @gray;
+		background-color: fadeout(@black,60%);
 
-			&:hover {
-				border-color: @gray-l1;
-			}
-			&:focus {
-				border-color: @primary-accent-color;
-				background-color: fadeout(@black,30%);
-			}
+		&:hover {
+			border-color: @gray-l1;
 		}
-	}
+		&:focus {
+			border-color: @primary-accent-color;
+			background-color: fadeout(@black,30%);
+		}
+	});
 }
 
 textarea.input {
@@ -106,14 +105,6 @@ textarea.input {
 	vertical-align: middle;
 }
 
-& when (@include-dark = true) {
-	.dark {
-		input, textarea, label {
-			color: #fff;
-		}
-	}
-}
-
 // attribute styles
 input.input,
 textarea.input {
@@ -132,21 +123,14 @@ textarea.input {
 		background-color: fadeout(@gray,80%);
 		opacity: 0.7;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-color: @gray-d1;
-			}
-		}
+		.dark-override({
+			border-color: @gray-d1;
+		});
 	}
 
 	// readonly
 	&[readonly] {
 		background-color: fadeout(@gray,90%);
-
-		& when (@include-dark = true) {
-			.dark & {
-			}
-		}
 	}
 }
 
@@ -470,11 +454,9 @@ textarea.input {
 		border-left-width: 0;
 		border-right-width: 0;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-color: @gray;
-			}
-		}
+		.dark-override({
+			border-color: @gray;
+		});
 
 		&:first-child {
 			border-left-width: @input-border-width;
@@ -604,21 +586,20 @@ input[type="radio"].radiobox + label {
 		transition-duration: 0;
 	}
 
-	& when (@include-dark = true) {
-		// on dark
-		.dark &:before {
+	.dark-override({
+		&:before {
 			border-color: @gray-d2;
 			background-color: #111;
 		}
 
-		.dark &:hover:before {
+		&:hover:before {
 			border-color: lighten(@gray-d2,10%);
 		}
 
-		.dark &:active:before {
+		&:active:before {
 			background-color: #000;
 		}
-	}
+	});
 }
 
 // border radius
@@ -641,11 +622,11 @@ input[type="radio"].radiobox:focus + label {
 		border-color: @primary-accent-color;
 	}
 
-	& when (@include-dark = true) {
-		.dark &:before {
+	.dark-override({
+		&:before {
 			border-color: @primary-accent-color;
 		}
-	}
+	});
 }
 
 input[type="checkbox"].checkbox + label,
@@ -674,12 +655,12 @@ input[type="radio"].radiobox + label　{
 		}
 	}
 
-	& when (@include-dark = true) {
-		.dark &:after {
+	.dark-override({
+		&:after {
 			@checkmark-svg-data: escape('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="none" stroke="@{color-l1}" stroke-width="@{checkbox-check-thickness}" d="M3 7l4 4 7-7" vector-effect="non-scaling-stroke"/></svg>');
 			background-image: url('data:image/svg+xml,@{checkmark-svg-data}');
 		}
-	}
+	});
 
 	.colorset(@checkbox-color);
 }
@@ -693,11 +674,12 @@ input[type="radio"].radiobox + label　{
 		background-color: @color-d1;
 	}
 
-	& when (@include-dark = true) {
-		.dark &:after {
+	.dark-override({
+		&:after {
 			background-color: @color-l1;
 		}
-	}
+	});
+
 	.colorset(@checkbox-color);
 }
 
@@ -723,11 +705,11 @@ input[type="radio"].radiobox:checked + label　{
 			border-color: @danger-color;
 		}
 
-		& when (@include-dark = true) {
-			.dark &:before {
+		.dark-override({
+			&:before {
 				border-color: @danger-color;
 			}
-		}
+		});
 	}
 }
 
@@ -738,11 +720,11 @@ input[type="radio"].radiobox.validation.error + label　{
 		border-color: @danger-color;
 	}
 
-	& when (@include-dark = true) {
-		.dark &:before {
+	.dark-override({
+		&:before {
 			border-color: @danger-color;
 		}
-	}
+	});
 }
 
 
@@ -760,13 +742,13 @@ fieldset:disabled input[type="radio"].radiobox + label {
 		opacity: 0.5;
 	}
 
-	& when (@include-dark = true) {
-		.dark &:before,
-		.dark &:hover:before {
+	.dark-override({
+		&:before,
+		&:hover:before {
 			background-color: fadeout(@gray-d2,60%);
 			border-color: fadeout(@gray,50%);
 		}
-	}
+	});
 }
 
 
@@ -824,22 +806,21 @@ fieldset:disabled input[type="radio"].radiobox + label {
 			transition-duration: 0;
 		}
 
-		& when (@include-dark = true) {
-			// on dark
-			.dark & {
+		.dark-override({
+			& {
 				border-color: @gray-d2;
 				background-color: #111;
 			}
 
-			.dark &:hover {
+			&:hover {
 				border-color: lighten(@gray-d2,10%);
 			}
 
-			.dark &:active {
+			&:active {
 				border-color: @primary-accent-color;
 				background-color: #000;
 			}
-		}
+		});
 	}
 
 	// highlight border on focus
@@ -894,11 +875,11 @@ fieldset:disabled input[type="radio"].radiobox + label {
 			}
 		}
 
-		& when (@include-dark = true) {
-			.dark &:after {
+		.dark-override({
+			&:after {
 				background-color: @color-l1;
 			}
-		}
+		});
 	}
 
 	&:not(.ab-type) label span:before {
@@ -931,12 +912,12 @@ fieldset:disabled input[type="radio"].radiobox + label {
 			background-color: multiply(@okay-color,@d2-additive);
 		}
 
-		& when (@include-dark = true) {
+		.dark-override({
 			// ticker color on dark
-			.dark & input[type="checkbox"]:checked + label span:after {
+			& input[type="checkbox"]:checked + label span:after {
 				background-color: screen(@okay-color,@l1-additive);
 			}
-		}
+		});
 	}
 
 	&.onoff-type.led {
@@ -946,12 +927,12 @@ fieldset:disabled input[type="radio"].radiobox + label {
 			background-color: #f00 !important;
 		}
 
-		& when (@include-dark = true) {
-			// ticker color on dark
-			.dark & label span:after {
+		// ticker color on dark
+		.dark-override({
+			label span:after {
 				border-color: #bbb;
 			}
-		}
+		});
 
 		input[type="checkbox"]:checked + label span:after {
 			background-color: saturate(screen(@okay-color,@l1-additive), 50%) !important;
@@ -985,12 +966,12 @@ fieldset:disabled input[type="radio"].radiobox + label {
 				border-color: fadeout(@gray-l1,50%);
 			}
 
-			& when (@include-dark = true) {
-				.dark &:before,
-				.dark &:hover:before {
+			.dark-override({
+				&:before,
+				&:hover:before {
 					border-color: fadeout(@gray,50%);
 				}
-			}
+			});
 		}
 	}
 
@@ -1083,19 +1064,17 @@ select.select {
 		width: 100%;
 	}
 
-	& when (@include-dark = true) {
-		// dark mode
-		.dark & {
-			background-color: #000;
-			color: #fff;
+	// dark mode
+	.dark-override({
+		background-color: #000;
+		color: #fff;
 
-			&[multiple] {
-				&:hover {
-					background-color: #000;
-				}
+		&[multiple] {
+			&:hover {
+				background-color: #000;
 			}
 		}
-	}
+	});
 }
 
 // * ================================= *
@@ -1515,42 +1494,39 @@ select.select {
 
 		}
 
-		& when (@include-dark = true) {
-			// dark
-			.dark & {
-				color: #fff;
+		.dark-override({
+			color: #fff;
 
-				.selecter-selected {
-					border-color: @gray;
-					background-color: fadeout(@black,60%);
-				}
+			.selecter-selected {
+				border-color: @gray;
+				background-color: fadeout(@black,60%);
+			}
 
-				&:hover .selecter-selected {
-					border-color: @gray-l1;
-				}
-				&:focus .selecter-selected {
-					border-color: @primary-accent-color;
-					background-color: fadeout(@black,30%);
-				}
+			&:hover .selecter-selected {
+				border-color: @gray-l1;
+			}
+			&:focus .selecter-selected {
+				border-color: @primary-accent-color;
+				background-color: fadeout(@black,30%);
+			}
 
 
-				.selecter-options {
-					background-color: #000;
-					box-shadow: @drop-shadow-deep, 0 0 1px 0 rgba(255,255,255,0.1);
-				}
+			.selecter-options {
+				background-color: #000;
+				box-shadow: @drop-shadow-deep, 0 0 1px 0 rgba(255,255,255,0.1);
+			}
 
-				.selecter-item {
-					&:hover {
-						background-color: rgba(255,255,255,.2);
-					}
-				}
-
-				&.disabled {
-
+			.selecter-item {
+				&:hover {
+					background-color: rgba(255,255,255,.2);
 				}
 			}
-		}
+
+			&.disabled {
+
+			}
+		});
 
 	}// end .selecter
 
-}// end include-dark guard
+}// end include-selecter guard

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -18,6 +18,21 @@
 	@color-d2: multiply(@color,@d2-additive);
 }
 
+// dark style overrides output mixin
+.dark-override(@rules) {
+	& when (@include-dark = true) {
+		& when (@use-webcomponents = false) {
+			.dark & {
+				@rules();
+			}
+		}
+		& when (@use-webcomponents = true) {
+			:host-context(.dark) & {
+				@rules();
+			}
+		}
+	}
+}
 
 /* drop shadow mixin */
 @drop-shadow: 0 2px 4px rgba(0,0,0,0.2);

--- a/less/modals.less
+++ b/less/modals.less
@@ -57,20 +57,18 @@
 		font-size: 1.2em;
 	}
 
-	& when (@include-dark = true) {
-		// dark style
-		.dark & {
-			background-color: #333;
+	// dark style
+	.dark-override({
+		background-color: #333;
 
-			.modal-header {
-				background-color: #444;
-			}
-
-			.btn-row {
-				border-top-color: #444;
-			}
+		.modal-header {
+			background-color: #444;
 		}
-	}
+
+		.btn-row {
+			border-top-color: #444;
+		}
+	});
 }
 
 // standard modal

--- a/less/modals.less
+++ b/less/modals.less
@@ -59,7 +59,7 @@
 
 	& when (@include-dark = true) {
 		// dark style
-		.dark &, &.ondark {
+		.dark & {
 			background-color: #333;
 
 			.modal-header {

--- a/less/paging.less
+++ b/less/paging.less
@@ -150,7 +150,7 @@
 
 	& when (@include-dark = true) {
 		// dark variants
-		&.ondark, .dark & {
+		.dark & {
 			.pg-block {
 				a {
 					color: #fff;

--- a/less/paging.less
+++ b/less/paging.less
@@ -148,42 +148,40 @@
 		vertical-align: middle;
 	}
 
-	& when (@include-dark = true) {
-		// dark variants
-		.dark & {
-			.pg-block {
-				a {
-					color: #fff;
-					background-color: #444;
+	// dark variants
+	.dark-override({
+		.pg-block {
+			a {
+				color: #fff;
+				background-color: #444;
 
-					&:hover {
-						color: @primary-accent-color;
-					}
-				}
-
-				&.active a {
-					color: #fff;
-					background-color: @color-l1;
-
-					.colorset(@primary-accent-color);
-				}
-
-				&.disabled {
-					opacity: 0.3;
+				&:hover {
+					color: @primary-accent-color;
 				}
 			}
+
+			&.active a {
+				color: #fff;
+				background-color: @color-l1;
+
+				.colorset(@primary-accent-color);
+			}
+
+			&.disabled {
+				opacity: 0.3;
+			}
 		}
-	}
+	});
 
 
 	// inline
 	&.inline {
 		.pg-block{
 
-			& when (@include-dark = true) {
-				.dark & a {
+			a {
+				.dark-override({
 					color: #fff;
-				}
+				});
 			}
 
 			a,

--- a/less/paging.less
+++ b/less/paging.less
@@ -132,25 +132,8 @@
 			&:hover .petalicon { transform: translateX(2px); }
 		}
 
-	}
-
-	.pg-ellipsis {
-		display: block;
-		float: left;
-		vertical-align: middle;
-		min-height: 20px;
-		padding: 8px 15px;
-		margin: 0 2px;
-		text-align: center;
-		color: #666;
-		overflow: hidden;
-		box-sizing: content-box;
-		vertical-align: middle;
-	}
-
-	// dark variants
-	.dark-override({
-		.pg-block {
+		// dark override
+		.dark-override({
 			a {
 				color: #fff;
 				background-color: #444;
@@ -170,14 +153,27 @@
 			&.disabled {
 				opacity: 0.3;
 			}
-		}
-	});
 
+		});
+	}
+
+	.pg-ellipsis {
+		display: block;
+		float: left;
+		vertical-align: middle;
+		min-height: 20px;
+		padding: 8px 15px;
+		margin: 0 2px;
+		text-align: center;
+		color: #666;
+		overflow: hidden;
+		box-sizing: content-box;
+		vertical-align: middle;
+	}
 
 	// inline
 	&.inline {
 		.pg-block{
-
 			a {
 				.dark-override({
 					color: #fff;

--- a/less/panels.less
+++ b/less/panels.less
@@ -24,7 +24,7 @@
 	}
 
 	& when (@include-dark = true) {
-		.dark &, &.ondark {
+		.dark & {
 			background-color: #444;
 			box-shadow: 0 1px 4px rgba(0,0,0,.1);
 

--- a/less/tables.less
+++ b/less/tables.less
@@ -14,8 +14,7 @@ table.table {
 	background-color: #fff;
 
 	& when (@include-dark = true) {
-		.dark &,
-		&.ondark {
+		.dark & {
 			background-color: #222;
 		}
 	}
@@ -38,8 +37,7 @@ table.table {
 		border-bottom: 1px solid #ddd;
 
 		& when (@include-dark = true) {
-			.dark &,
-			&.ondark {
+			.dark & {
 				border-bottom-color: #444;
 			}
 		}
@@ -54,8 +52,7 @@ table.table {
 		border-bottom: 2px solid #ccc;
 
 		& when (@include-dark = true) {
-			.dark &,
-			&.ondark {
+			.dark & {
 				border-bottom-color: #555;
 			}
 		}
@@ -66,8 +63,7 @@ table.table {
 		border-top: 2px solid #ccc;
 
 		& when (@include-dark = true) {
-			.dark &,
-			&.ondark {
+			.dark & {
 				border-top-color: #555;
 			}
 		}
@@ -85,8 +81,7 @@ table.table {
 			border-right: 1px solid #ddd;
 
 			& when (@include-dark = true) {
-				.dark &,
-				&.ondark {
+				.dark & {
 					border-right-color: #444;
 				}
 			}
@@ -102,8 +97,7 @@ table.table {
 		border: 1px solid #ddd;
 
 		& when (@include-dark = true) {
-			.dark &,
-			&.ondark {
+			.dark & {
 				border-color: #444;
 			}
 		}
@@ -116,8 +110,7 @@ table.table {
 			background-color: #fcfcfc;
 
 			& when (@include-dark = true) {
-				.dark &,
-				&.ondark {
+				.dark & {
 					background-color: fadeout(#fff,95%);
 				}
 			}
@@ -132,8 +125,7 @@ table.table {
 			background-color: #f7f7f7;
 
 			& when (@include-dark = true) {
-				.dark &,
-				&.ondark {
+				.dark & {
 					background-color: fadeout(#fff,90%);
 				}
 			}

--- a/less/tables.less
+++ b/less/tables.less
@@ -13,11 +13,9 @@ table.table {
 	width: 100%;
 	background-color: #fff;
 
-	& when (@include-dark = true) {
-		.dark & {
-			background-color: #222;
-		}
-	}
+	.dark-override({
+		background-color: #222;
+	});
 
 	caption {
 		text-align: left;
@@ -36,11 +34,9 @@ table.table {
 		text-align: left;
 		border-bottom: 1px solid #ddd;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-bottom-color: #444;
-			}
-		}
+		.dark-override({
+			border-bottom-color: #444;
+		});
 
 		&.nowrap {
 			white-space: nowrap;
@@ -51,22 +47,18 @@ table.table {
 	thead tr:last-child td {
 		border-bottom: 2px solid #ccc;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-bottom-color: #555;
-			}
-		}
+		.dark-override({
+			border-bottom-color: #555;
+		});
 	}
 
 	tfoot tr:first-child th,
 	tfoot tr:first-child td {
 		border-top: 2px solid #ccc;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-top-color: #555;
-			}
-		}
+		.dark-override({
+			border-top-color: #555;
+		});
 	}
 
 
@@ -80,11 +72,9 @@ table.table {
 		th, td {
 			border-right: 1px solid #ddd;
 
-			& when (@include-dark = true) {
-				.dark & {
-					border-right-color: #444;
-				}
-			}
+			.dark-override({
+				border-right-color: #444;
+			});
 
 			&:last-child {
 				border-right: none;
@@ -96,11 +86,9 @@ table.table {
 	&.table-outer-borders {
 		border: 1px solid #ddd;
 
-		& when (@include-dark = true) {
-			.dark & {
-				border-color: #444;
-			}
-		}
+		.dark-override({
+			border-color: #444;
+		});
 
 	}
 
@@ -109,11 +97,9 @@ table.table {
 		tr:nth-child(2n) {
 			background-color: #fcfcfc;
 
-			& when (@include-dark = true) {
-				.dark & {
-					background-color: fadeout(#fff,95%);
-				}
-			}
+			.dark-override({
+				background-color: fadeout(#fff,95%);
+			});
 
 		}
 	}
@@ -124,11 +110,9 @@ table.table {
 		tbody tr:hover td {
 			background-color: #f7f7f7;
 
-			& when (@include-dark = true) {
-				.dark & {
-					background-color: fadeout(#fff,90%);
-				}
-			}
+			.dark-override({
+				background-color: fadeout(#fff,90%);
+			});
 		}
 	}
 

--- a/less/typography.less
+++ b/less/typography.less
@@ -102,11 +102,9 @@ code {
 	letter-spacing: 0;
 	text-transform: none;
 
-	& when (@include-dark = true) {
-		.dark & {
-			background-color: fadeout(#fff,90%);
-		}
-	}
+	.dark-override({
+		background-color: fadeout(#fff,90%);
+	});
 }
 
 pre {

--- a/less/variables.less
+++ b/less/variables.less
@@ -15,6 +15,7 @@
 
 // global settings
 @include-dark: true;
+@use-webcomponents: false; // output :host-context(.dark) instead of plain .dark class
 
 // layout
 @container-width: 980px;


### PR DESCRIPTION
When using Petal modules in a web component stylesheet (importing in directly), existing `.dark` overrides that are supposed to apply when a parent element has the class doesn't work properly because of scoping. By using `:host-context(.dark)` pseudo class Petal is able to target shadow hosts with the `.dark` class outside of the shadow DOM.

This PR adds a new `@use-webcomponents` global variable which defaults to false, but can be turned on in cases needed. Also converts existing `.dark &` style overrides to use `.dark-override()` mixin to make code more cleaner.